### PR TITLE
[Filter Tasks Planner] Merge from bugfix/automation/filter-tasks-planner/sys-frozen into dev/automation/filter-tasks-planner

### DIFF
--- a/automations/filter_tasks_planner/FilterTasksPlanner.py
+++ b/automations/filter_tasks_planner/FilterTasksPlanner.py
@@ -2,8 +2,14 @@
 from src import main
 from src import utils
 from pathlib import Path
+import sys
 
-config_path = Path(__file__).resolve().parent / 'settings' / 'mainsettings.yml'
+if getattr(sys, 'frozen', False):
+    base_path = Path(sys.executable).parent
+else:
+    base_path = Path(__file__).resolve().parent
+
+config_path = base_path / 'settings' / 'mainsettings.yml'
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
### 📝 O que foi feito

Feito o fix do sys.frozen que impedia a execução do programa Filter Tasks Planner por causa das dependências que estavam no contexto de build e não no contexto de diretório atual do executável.

### 🔗 Referências
- Issues: #26 
- Version: `release FilterTasksPlanner 1.0.0` 