### PR TITLE
Merge form bugfix/games/guess/exception-missing-icon-words into dev/games/guess

### DIFF
--- a/games/guess/src/main.py
+++ b/games/guess/src/main.py
@@ -8,15 +8,21 @@ from src.logger import setup_logger, log_error, close_logger
 def main(): # funcao principal
     setup_logger()
     
-    error = load_words() # valida se o arquivo foi carregado com sucesso
-    if error:
-        show_error(error)
-        log_error(error.replace('\n', ' '))
+    words_error = load_words() # valida se o arquivo foi carregado com sucesso
+    icon_path, icon_error = get_icon_path() # valida se o icon ainda existe
+    
+    if words_error and icon_error:
+        log_error(icon_error)
+        log_error(words_error.replace('\n', ' '))
         return
     
-    icon_path, icon_error = get_icon_path() # valida se o icon ainda existe
     if icon_error:
         log_error(icon_error)
+        return
+    
+    if words_error:
+        show_error(words_error)
+        log_error(words_error.replace('\n', ' '))
         return
     
     close_logger()


### PR DESCRIPTION
### 📝 O que foi feito
Correção na validação de ausência dos arquivos `assets/lamp.ico` e `data/words.txt`

### 🔗 Referências
- Issues: #8 
- Version: `release Guess 1.0.0` 